### PR TITLE
Relax requirements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,8 @@ jobs:
           - windows-latest
           - macos-latest
         python:
+          - '3.9'
+          - '3.10'
           - '3.11'
           - '3.12'
           - '3.13'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
   { name="Eeems", email="eeems@eeems.email" },
 ]
 description = "Library for read only interactions with an ext4 filesystem"
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
@@ -16,6 +16,8 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cachetools==5.3.2
-crcmod==1.7
+cachetools~=5.3
+crcmod~=1.7


### PR DESCRIPTION
Python 3.9 is still not EOL and it seems that it works without problems on Python 3.9, so I think it should be fine to decrease it.